### PR TITLE
Vtol rework modified

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2255,13 +2255,13 @@ set_vtol_state_rc(struct vehicle_status_s *status_local, struct vtol_vehicle_sta
 	/* set vtol state according to RC regime switch */
 	transition_result_t res = TRANSITION_NOT_CHANGED;
 
-	if (sp_man->regime_switch == sp_man->HOVER && !vtol_status->vtol_in_rw_mode) {		/* vehicle is in mc mode */
+	if (sp_man->aux1 < 0.0f && !vtol_status->vtol_in_rw_mode) {		/* vehicle is in mc mode */
 		vtol_status->vtol_in_rw_mode = true;
 		res = TRANSITION_CHANGED;
 		if (status_local->is_vtol && !status_local->is_rotary_wing) {
 			status_local->is_rotary_wing = true;
 		}
-	} else if(sp_man->regime_switch == sp_man->CRUISE && vtol_status->vtol_in_rw_mode){
+	} else if(sp_man->aux1 >= 0.0f && vtol_status->vtol_in_rw_mode){
 		vtol_status->vtol_in_rw_mode = false;
 		res = TRANSITION_CHANGED;
 		if (status_local->is_vtol && status_local->is_rotary_wing) {


### PR DESCRIPTION
Having vtol_status published in commander make sense since the flags it sets can be used in other vtol modules without checking for switch positions in all modules individually. Also, in future, it might be necessary to allow/deny vtol transition with the switch when flying in hands free auto mode. Commander would be a good place to allow/deny such transitions(Imagine the vehicle doing a auto_mission and the pilot switches the transition switch).

I tried to include the 'vtol_fw_permanent_stab' thing with the parameter as you do in the vtol_att_control app, but i have not tested that, since we don't use it. The transition switch is tested and now works fine for us. 
